### PR TITLE
Add Supabase client initialization

### DIFF
--- a/supabase/client.ts
+++ b/supabase/client.ts
@@ -1,0 +1,5 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = 'https://ihjpqtvnvhaekarqdhpf.supabase.co'
+const supabaseKey = process.env.SUPABASE_KEY
+export const supabase = createClient(supabaseUrl, supabaseKey)


### PR DESCRIPTION
## Summary
- create Supabase client instance using `@supabase/supabase-js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689260a4a54883229ac25d2aab2728e0