### PR TITLE
Rename function folder for GitHub→Supabase sync and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,42 @@
 # Telegram Dynamic Pool Bot Setup
 
 This README provides instructions for setting up the Telegram Dynamic Pool Bot.
+
+## Option 2: GitHub → Supabase Sync Only
+
+If you're using Codex with GitHub and Supabase, Deno doesn't need to be installed locally.
+
+- Make code edits directly in GitHub or Codex.
+- Push changes to `supabase/functions/telegram-bot/index.ts`.
+- Supabase deploys Edge Functions automatically through GitHub Actions.
+
+This approach works from any device and avoids a local Deno setup. Expect a short delay of roughly 5–10 seconds for GitHub to Supabase synchronization.
+
+## Supabase Connection Test
+
+Run `npm test` to execute a small script that verifies your `.env` configuration and confirms the `bot_users` table is reachable in Supabase.
+
+## Command Map
+
+### Users
+- `/start`
+- `/register`
+- `/wallet`
+- `/invest`
+- `/myshares`
+- `/report`
+- `/withdraw`
+- `/support`
+- `/help`
+
+### Admins
+- `/admin`
+- `/listusers`
+- `/approve`
+- `/distribute`
+- `/sendreport`
+- `/broadcast`
+- `/listinvestments`
+- `/toggleaccess`
+
+

--- a/index.js
+++ b/index.js
@@ -1,0 +1,14 @@
+import { supabase } from './lib/supabase.js';
+
+async function main() {
+  const { data, error } = await supabase.from('bot_users').select('*').limit(1);
+
+  if (error) {
+    console.error('Table "bot_users" not found:', error.message);
+    return;
+  }
+
+  console.log('Table "bot_users" exists.');
+}
+
+main();

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_ANON_KEY
+);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "dynamic-codex",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node test-supabase.js"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.39.6",
+    "dotenv": "^16.4.5"
+  }
+}

--- a/supabase/functions/telegram-bot/index.ts
+++ b/supabase/functions/telegram-bot/index.ts
@@ -1,4 +1,14 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN");
+const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
+const BINANCE_API_KEY = Deno.env.get("BINANCE_API_KEY");
+const BINANCE_SECRET_KEY = Deno.env.get("BINANCE_SECRET_KEY");
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY");
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+const ADMIN_USER_IDS = ["225513686"];
 
 serve(async (req) => {
   if (req.method !== "POST") {
@@ -11,18 +21,12 @@ serve(async (req) => {
     return new Response("No message to process", { status: 200 });
   }
 
-  // Get secrets from environment
-  const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
-  const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-  const { createClient } = await import("https://esm.sh/@supabase/supabase-js@2.38.3");
-  const supabase = createClient(supabaseUrl, supabaseKey);
+  const supabase = createClient(SUPABASE_URL!, SUPABASE_SERVICE_ROLE_KEY!);
 
-  // Prepare message data
   const { id: user_id, username } = message.from;
   const text = message.text || "";
   const date = new Date((message.date || Date.now()) * 1000).toISOString();
 
-  // Insert message record
   const { error } = await supabase
     .from("messages")
     .insert([{ user_id, username, text, date }]);

--- a/test-supabase.js
+++ b/test-supabase.js
@@ -1,0 +1,15 @@
+import { supabase } from './lib/supabase.js';
+
+export async function testSupabaseConnection() {
+  const { error } = await supabase.from('bot_users').select('id').limit(1);
+  if (error) {
+    console.error('Supabase connection failed:', error.message);
+    return false;
+  }
+  console.log('Supabase connection successful.');
+  return true;
+}
+
+if (import.meta.main) {
+  testSupabaseConnection();
+}


### PR DESCRIPTION
## Summary
- rename Edge Function folder from `telegram-webhook` to `telegram-bot`
- document GitHub→Supabase sync workflow with no local Deno requirement
- list available user and admin bot commands in README
- add Node helper to load `.env` and initialize Supabase client
- add script to verify `bot_users` table exists
- declare environment variable constants for tokens, keys, and Supabase config in the Edge Function
- add `test-supabase.js` script and wire it to `npm test` to validate Supabase connectivity
- simplify Supabase client initialization

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@supabase%2fsupabase-js)*
- `npm test` *(fails: Cannot find package '@supabase/supabase-js')*


------
https://chatgpt.com/codex/tasks/task_e_689260a4a54883229ac25d2aab2728e0