### PR TITLE
feat: add EA report edge function and schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ The database migration will be automatically applied when you connect to Supabas
 - Row Level Security (RLS) policies
 - Real-time subscriptions enabled
 
-### 5. Deploy the Edge Function
+### 5. Deploy Edge Functions
 
-The edge function is located in `supabase/functions/telegram-webhook/`. It will be automatically deployed when you connect to Supabase.
+The Telegram webhook function lives in `supabase/functions/telegram-webhook/`.
+An additional `ea-report` function under `supabase/functions/ea-report/` accepts JSON performance reports from your MQL5 Expert Advisor, stores them in the `ea_reports` table, and forwards a summary to Telegram.
+Both functions are automatically deployed when you connect to Supabase.
 
 ### 6. Set Telegram Webhook
 

--- a/supabase/functions/ea-report/index.ts
+++ b/supabase/functions/ea-report/index.ts
@@ -1,0 +1,86 @@
+import { createClient } from "npm:@supabase/supabase-js@2.53.0";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 200, headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  const telegramToken = Deno.env.get("TELEGRAM_BOT_TOKEN");
+  const chatId = Deno.env.get("ADMIN_USER_ID");
+
+  if (!supabaseUrl || !supabaseKey) {
+    return new Response(
+      JSON.stringify({ error: "Missing Supabase credentials" }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = await req.json();
+  } catch (_e) {
+    return new Response(JSON.stringify({ error: "Invalid JSON" }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  const { error } = await supabase.from("ea_reports").insert({
+    report: payload,
+  });
+  if (error) {
+    return new Response(
+      JSON.stringify({
+        error: "Database insert failed",
+        details: error.message,
+      }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  if (telegramToken && chatId) {
+    const summary = `EA Report:\n<pre>${
+      JSON.stringify(payload, null, 2)
+    }</pre>`;
+    try {
+      await fetch(`https://api.telegram.org/bot${telegramToken}/sendMessage`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          chat_id: chatId,
+          text: summary,
+          parse_mode: "HTML",
+        }),
+      });
+    } catch (_e) {
+      /* ignore telegram errors */
+    }
+  }
+
+  return new Response(JSON.stringify({ status: "ok" }), {
+    status: 200,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+});

--- a/supabase/migrations/20250913120000_create_ea_reports.sql
+++ b/supabase/migrations/20250913120000_create_ea_reports.sql
@@ -1,0 +1,23 @@
+/*
+  Create ea_reports table for storing EA performance stats
+*/
+
+CREATE TABLE IF NOT EXISTS ea_reports (
+  id serial PRIMARY KEY,
+  report jsonb NOT NULL,
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE ea_reports ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role can insert ea_reports"
+  ON ea_reports
+  FOR INSERT
+  TO service_role
+  USING (true);
+
+CREATE POLICY "Authenticated users can read ea_reports"
+  ON ea_reports
+  FOR SELECT
+  TO authenticated
+  USING (true);


### PR DESCRIPTION
## Summary
- add `ea-report` Supabase Edge Function for MQL5 EA stats
- create `ea_reports` table with RLS policies
- document new edge function in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `/root/.deno/bin/deno fmt supabase/functions/ea-report/index.ts`

------
https://chatgpt.com/codex/tasks/task_e_6893ed60171083229afeaf27b24bcf0e