### PR TITLE
Add MQL5 EA template with Supabase reporting

### DIFF
--- a/mql5/LorentzianClassificationEA.mq5
+++ b/mql5/LorentzianClassificationEA.mq5
@@ -1,0 +1,146 @@
+#property copyright "2024"
+#property version   "1.00"
+#property strict
+
+// Simplified port of the "Lorentzian Classification" Pine Script indicator
+// Implements a basic KNN classifier using Lorentzian distance on RSI and ADX features.
+// Opens trades based on predicted direction and reports actions to Supabase via WebRequest.
+
+#include <Trade/Trade.mqh>
+CTrade trade;
+
+input int    NeighborsCount = 8;     // number of neighbors to consider
+input int    MaxBarsBack     = 2000;  // max history size
+input int    RSI_Period      = 14;    // feature 1
+input int    ADX_Period      = 14;    // feature 2
+input double Lots            = 0.10;  // lot size for orders
+
+string SupabaseURL = "https://xyz.supabase.co/functions/v1/ea-report"; // replace with your endpoint
+
+// feature storage
+struct FeatureRow
+{
+   double rsi;
+   double adx;
+   int    label; // 1 long, -1 short, 0 neutral
+};
+
+FeatureRow rows[];
+int totalRows = 0;
+
+int lastProcessedBar = -1;
+
+int OnInit()
+{
+   ArrayResize(rows, MaxBarsBack);
+   return(INIT_SUCCEEDED);
+}
+
+void OnTick()
+{
+   // process only on new bar
+   int currentBar = iBars(_Symbol, PERIOD_CURRENT);
+   if(currentBar == lastProcessedBar)
+      return;
+   lastProcessedBar = currentBar;
+
+   double rsi = iRSI(_Symbol, PERIOD_CURRENT, RSI_Period, PRICE_CLOSE, 0);
+   double adx = iADX(_Symbol, PERIOD_CURRENT, ADX_Period, 0, PRICE_CLOSE, 0);
+
+   // store feature row
+   if(totalRows < MaxBarsBack)
+      totalRows++;
+   for(int i = totalRows-1; i > 0; --i)
+      rows[i] = rows[i-1];
+   rows[0].rsi = rsi;
+   rows[0].adx = adx;
+   rows[0].label = 0; // placeholder for future bar label
+
+   // update label for bar 4 bars ago
+   if(totalRows > 4)
+   {
+      double futureClose = iClose(_Symbol, PERIOD_CURRENT, 0);
+      double pastClose   = iClose(_Symbol, PERIOD_CURRENT, 4);
+      rows[4].label = (futureClose > pastClose) ? 1 : (futureClose < pastClose ? -1 : 0);
+   }
+
+   // skip until we have at least neighborsCount bars with labels
+   if(totalRows <= NeighborsCount + 4)
+      return;
+
+   // compute Lorentzian distances
+   double distances[];
+   ArrayResize(distances, 0);
+   int predictions[];
+   ArrayResize(predictions, 0);
+
+   double lastDistance = -1.0;
+   for(int i = 4; i < totalRows; i++) // skip bars without label
+   {
+      if(i % 4 != 0) continue; // enforce spacing every 4 bars
+      double d = MathLog(1 + MathAbs(rsi - rows[i].rsi)) +
+                 MathLog(1 + MathAbs(adx - rows[i].adx));
+      if(d >= lastDistance)
+      {
+         lastDistance = d;
+         ArrayPush(distances, d);
+         ArrayPush(predictions, rows[i].label);
+         if(ArraySize(predictions) > NeighborsCount)
+         {
+            lastDistance = distances[int(NeighborsCount*3/4)];
+            ArrayRemove(distances, 0);
+            ArrayRemove(predictions, 0);
+         }
+      }
+   }
+
+   // aggregate prediction
+   int sum = 0;
+   for(int i = 0; i < ArraySize(predictions); ++i)
+      sum += predictions[i];
+   int signal = 0;
+   if(sum > 0) signal = 1; else if(sum < 0) signal = -1;
+
+   ManageTrades(signal);
+}
+
+void ManageTrades(int signal)
+{
+   bool hasPosition = PositionSelect(_Symbol);
+   int direction = 0;
+   if(hasPosition)
+      direction = (PositionGetInteger(POSITION_TYPE) == POSITION_TYPE_BUY) ? 1 : -1;
+
+   if(signal > 0 && (!hasPosition || direction < 0))
+   {
+      if(hasPosition) trade.PositionClose(_Symbol);
+      if(trade.Buy(Lots))
+         SendReport("buy");
+   }
+   else if(signal < 0 && (!hasPosition || direction > 0))
+   {
+      if(hasPosition) trade.PositionClose(_Symbol);
+      if(trade.Sell(Lots))
+         SendReport("sell");
+   }
+}
+
+void SendReport(string action)
+{
+   string json = StringFormat("{\"symbol\":\"%s\",\"action\":\"%s\"}", _Symbol, action);
+   char post[]; StringToCharArray(json, post);
+   char result[];
+   string headers = "Content-Type: application/json\r\n";
+   int timeout = 5000;
+   int res = WebRequest("POST", SupabaseURL, headers, timeout, post, result, NULL);
+   if(res == -1)
+      Print("WebRequest error: ", GetLastError());
+   else
+      Print("Report sent: ", json);
+}
+
+void OnDeinit(const int reason)
+{
+   // nothing to clean up
+}
+

--- a/mql5/MA_Cross_EA.mq5
+++ b/mql5/MA_Cross_EA.mq5
@@ -1,0 +1,71 @@
+#property copyright "2024"
+#property version   "1.00"
+#property strict
+
+// Simple Moving Average crossover EA template
+// Sends trade updates to Supabase edge function via WebRequest
+
+input int    FastMA = 9;
+input int    SlowMA = 21;
+input double Lots   = 0.10;
+
+#include <Trade/Trade.mqh>
+CTrade trade;
+
+int fastHandle;
+int slowHandle;
+
+int OnInit()
+{
+   fastHandle = iMA(_Symbol, PERIOD_CURRENT, FastMA, 0, MODE_EMA, PRICE_CLOSE);
+   slowHandle = iMA(_Symbol, PERIOD_CURRENT, SlowMA, 0, MODE_EMA, PRICE_CLOSE);
+   return INIT_SUCCEEDED;
+}
+
+void OnTick()
+{
+   double fast[2];
+   double slow[2];
+   if(CopyBuffer(fastHandle,0,0,2,fast) <= 0) return;
+   if(CopyBuffer(slowHandle,0,0,2,slow) <= 0) return;
+
+   bool crossUp   = fast[1] < slow[1] && fast[0] > slow[0];
+   bool crossDown = fast[1] > slow[1] && fast[0] < slow[0];
+
+   if(crossUp)
+   {
+      if(PositionSelect(_Symbol)) trade.PositionClose(_Symbol);
+      trade.Buy(Lots);
+      SendReport("buy");
+   }
+   else if(crossDown)
+   {
+      if(PositionSelect(_Symbol)) trade.PositionClose(_Symbol);
+      trade.Sell(Lots);
+      SendReport("sell");
+   }
+}
+
+void SendReport(string action)
+{
+   string url = "https://xyz.supabase.co/functions/v1/ea-report"; // replace with your endpoint
+   string json = StringFormat("{\"symbol\":\"%s\",\"action\":\"%s\",\"profit\":%f}",
+                              _Symbol, action, AccountInfoDouble(ACCOUNT_PROFIT));
+   char post[];
+   StringToCharArray(json, post);
+
+   char result[];
+   string headers = "Content-Type: application/json\r\n";
+   int timeout = 5000;
+   int res = WebRequest("POST", url, headers, timeout, post, result, NULL);
+   if(res == -1)
+      Print("WebRequest error: ", GetLastError());
+   else
+      Print("Report sent: ", json);
+}
+
+void OnDeinit(const int reason)
+{
+   IndicatorRelease(fastHandle);
+   IndicatorRelease(slowHandle);
+}


### PR DESCRIPTION
## Summary
- add an MQL5 Expert Advisor template implementing a moving-average crossover and reporting to Supabase via WebRequest

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_6893ed60171083229afeaf27b24bcf0e