### PR TITLE
Optimize MQL5 EAs for faster data access

### DIFF
--- a/mql5/MA_Cross_EA.mq5
+++ b/mql5/MA_Cross_EA.mq5
@@ -14,16 +14,23 @@ CTrade trade;
 
 int fastHandle;
 int slowHandle;
+datetime lastBarTime = 0;
 
 int OnInit()
 {
    fastHandle = iMA(_Symbol, PERIOD_CURRENT, FastMA, 0, MODE_EMA, PRICE_CLOSE);
    slowHandle = iMA(_Symbol, PERIOD_CURRENT, SlowMA, 0, MODE_EMA, PRICE_CLOSE);
+   if(fastHandle==INVALID_HANDLE || slowHandle==INVALID_HANDLE)
+      return INIT_FAILED;
    return INIT_SUCCEEDED;
 }
 
 void OnTick()
 {
+   datetime barTime = iTime(_Symbol, PERIOD_CURRENT, 0);
+   if(barTime == lastBarTime) return;
+   lastBarTime = barTime;
+
    double fast[2];
    double slow[2];
    if(CopyBuffer(fastHandle,0,0,2,fast) <= 0) return;


### PR DESCRIPTION
## Summary
- Cache RSI and ADX indicator handles in Lorentzian Classification EA to avoid recalculating values on every tick and release handles during deinitialization
- Batch-fetch daily highs and lows for ADR calculations to minimize repeated symbol data requests
- Process Moving Average crossover logic only on new bars and validate indicator handles for safer initialization

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894fa219e948322bfb6281e183710c4