### PR TITLE
docs: add health verification section

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,32 @@ npm install
 npm run dev
 ```
 
+## Health & Verification
+
+Run local diagnostics to ensure your functions are configured correctly:
+
+```bash
+npm run verify:functions
+```
+
+This script checks:
+
+- Required environment secrets are set
+- Telegram webhook points to your project
+- Edge functions respond with `{ pong: true }`
+
+Common fixes:
+
+- **Reset webhook**
+  ```bash
+  curl "https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook" \
+    -d url=https://<YOUR_PROJECT>.supabase.co/functions/v1/telegram-webhook
+  ```
+- **Set environment secrets**
+  ```bash
+  supabase secrets set TELEGRAM_BOT_TOKEN="<TOKEN>" SUPABASE_SERVICE_ROLE_KEY="<KEY>" SUPABASE_URL="https://<YOUR_PROJECT>.supabase.co"
+  ```
+
 ## Security
 
 - All database operations use Row Level Security (RLS)


### PR DESCRIPTION
## Summary
- document Health & Verification workflow to run `npm run verify:functions`
- include checks covered and commands for resetting webhook and env secrets

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896f7aae9148322809c7e3ae1e613ac