### PR TITLE
ci: add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run verify:functions
+      - name: Deploy changed functions
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            CHANGED=$(git ls-files 'supabase/functions/*')
+          else
+            CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} -- 'supabase/functions/*')
+          fi
+          if [ -n "$CHANGED" ]; then
+            for fn in $(echo "$CHANGED" | cut -d/ -f3 | sort -u); do
+              npx supabase functions deploy "$fn" --project-ref "$SUPABASE_PROJECT_ID"
+            done
+          else
+            echo "No functions changed"
+          fi
+      - name: Build and upload webapp
+        run: npm run webapp:build && npm run webapp:upload
+      - name: Set webhook
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_WEBHOOK_URL: ${{ secrets.TELEGRAM_WEBHOOK_URL }}
+        run: |
+          if npm run | grep -q 'set-webhook'; then
+            npm run set-webhook
+          else
+            curl -sS "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook?url=$TELEGRAM_WEBHOOK_URL"
+          fi
+      - run: npm run verify:functions


### PR DESCRIPTION
## Summary
- add deploy workflow with concurrency and function-specific deployment
- trigger workflow on main pushes and manual runs

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896fc4e34808322ada1f249eb3ce128