### PR TITLE
feat: add OCR abstraction

### DIFF
--- a/packages/ocr/index.ts
+++ b/packages/ocr/index.ts
@@ -1,0 +1,47 @@
+// BEGIN OCR_ABSTRACTION
+import { OcrResult, OcrVendor } from './types.ts';
+
+const cache = new Map<string, OcrResult>();
+
+const vendorFactories: Record<string, () => OcrVendor> = {
+  none: () => ({
+    async run(): Promise<OcrResult> {
+      throw new Error('OCR provider not configured');
+    },
+  }),
+};
+
+function getEnv(name: string): string | undefined {
+  if (typeof Deno !== 'undefined' && typeof Deno.env?.get === 'function') {
+    return Deno.env.get(name);
+  }
+  return process.env[name];
+}
+
+function createVendor(): OcrVendor {
+  const provider = getEnv('OCR_PROVIDER') || 'none';
+  const factory = vendorFactories[provider];
+  if (!factory) {
+    throw new Error(`Unsupported OCR provider: ${provider}`);
+  }
+  return factory();
+}
+
+function cacheKey(input: unknown, opts: Record<string, unknown>): string {
+  const base = typeof input === 'string' ? input : JSON.stringify(input);
+  return JSON.stringify({ base, opts });
+}
+
+export async function runOCR(
+  input: unknown,
+  opts: Record<string, unknown> = {},
+): Promise<OcrResult> {
+  const key = cacheKey(input, opts);
+  const cached = cache.get(key);
+  if (cached) return cached;
+  const vendor = createVendor();
+  const result = await vendor.run(input, opts);
+  cache.set(key, result);
+  return result;
+}
+// END OCR_ABSTRACTION

--- a/packages/ocr/types.ts
+++ b/packages/ocr/types.ts
@@ -1,0 +1,12 @@
+// BEGIN OCR_ABSTRACTION
+export interface OcrResult {
+  text: string;
+  fields?: Record<string, string>;
+  confidence: number;
+  meta: Record<string, unknown>;
+}
+
+export interface OcrVendor {
+  run(input: unknown, opts?: Record<string, unknown>): Promise<OcrResult>;
+}
+// END OCR_ABSTRACTION


### PR DESCRIPTION
## Summary
- add OCR result and vendor interfaces
- add OCR factory and caching run function

## Testing
- `npm run check:versions` *(fails: Missing script)*
- `npm run check:secrets` *(fails: Missing script)*
- `npm run verify:functions` *(fails: Missing script)*
- `npm run lint packages/ocr`


------
https://chatgpt.com/codex/tasks/task_e_68970446c3d08322ae72eff297e709f2