### PR TITLE
feat: add OCR vendor adapters

### DIFF
--- a/packages/ocr/adapters/ocrspace.ts
+++ b/packages/ocr/adapters/ocrspace.ts
@@ -1,0 +1,58 @@
+// BEGIN OCRSPACE_ADAPTER
+import { OcrVendor } from '../types';
+
+const API_URL = 'https://api.ocr.space/parse/image';
+const timeoutMs = 20_000;
+const maxRetries = 3;
+
+function getEnv(key: string): string | undefined {
+  // Support both Node.js and Deno environments
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const env: any = typeof Deno !== 'undefined' ? Deno.env : process.env;
+  return env?.get ? env.get(key) : env?.[key];
+}
+
+async function callApi(base64: string): Promise<string> {
+  const apiKey = getEnv('OCRSPACE_API_KEY');
+  if (!apiKey) throw new Error('Missing OCRSPACE_API_KEY');
+  const form = new FormData();
+  form.append('base64Image', `data:image/png;base64,${base64}`);
+  form.append('language', 'eng');
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(API_URL, {
+      method: 'POST',
+      headers: { apikey: apiKey },
+      body: form,
+      signal: controller.signal,
+    });
+    const json = await res.json();
+    return json.ParsedResults?.[0]?.ParsedText ?? '';
+  } finally {
+    clearTimeout(id);
+  }
+}
+
+async function recognize(base64: string): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await callApi(base64);
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError;
+}
+
+export const ocrspace: OcrVendor = {
+  name: 'ocrspace',
+  timeoutMs,
+  maxRetries,
+  usdPerImage: 0.0005,
+  recognize,
+};
+
+export default ocrspace;
+// END OCRSPACE_ADAPTER

--- a/packages/ocr/adapters/tesseract.ts
+++ b/packages/ocr/adapters/tesseract.ts
@@ -1,0 +1,44 @@
+// BEGIN TESSERACT_ADAPTER
+import { OcrVendor } from '../types';
+
+const timeoutMs = 30_000;
+const maxRetries = 0;
+
+function base64ToUint8Array(base64: string): Uint8Array {
+  if (typeof atob === 'function') {
+    const binary = atob(base64);
+    const len = binary.length;
+    const bytes = new Uint8Array(len);
+    for (let i = 0; i < len; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  }
+  // Node.js fallback
+  return Uint8Array.from(Buffer.from(base64, 'base64'));
+}
+
+async function recognize(base64: string): Promise<string> {
+  // Using `any` because tesseract.js types are unavailable without installing the package.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mod: any = await import('tesseract.js');
+  const worker = await mod.createWorker();
+  try {
+    await worker.load();
+    await worker.loadLanguage('eng');
+    await worker.initialize('eng');
+    const { data } = await worker.recognize(base64ToUint8Array(base64));
+    return data.text as string;
+  } finally {
+    await worker.terminate();
+  }
+}
+
+export const tesseract: OcrVendor = {
+  name: 'tesseract',
+  timeoutMs,
+  maxRetries,
+  usdPerImage: 0,
+  recognize,
+};
+
+export default tesseract;
+// END TESSERACT_ADAPTER

--- a/packages/ocr/adapters/vision.ts
+++ b/packages/ocr/adapters/vision.ts
@@ -1,0 +1,63 @@
+// BEGIN VISION_ADAPTER
+import { OcrVendor } from '../types';
+
+const API_URL = 'https://vision.googleapis.com/v1/images:annotate';
+const timeoutMs = 10_000;
+const maxRetries = 2;
+
+function getEnv(key: string): string | undefined {
+  // Support both Node.js and Deno environments
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const env: any = typeof Deno !== 'undefined' ? Deno.env : process.env;
+  return env?.get ? env.get(key) : env?.[key];
+}
+
+async function callApi(base64: string): Promise<string> {
+  const apiKey = getEnv('GOOGLE_VISION_API_KEY');
+  if (!apiKey) throw new Error('Missing GOOGLE_VISION_API_KEY');
+  const body = {
+    requests: [
+      {
+        image: { content: base64 },
+        features: [{ type: 'TEXT_DETECTION' }],
+      },
+    ],
+  };
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${API_URL}?key=${apiKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const json = await res.json();
+    return json.responses?.[0]?.fullTextAnnotation?.text ?? '';
+  } finally {
+    clearTimeout(id);
+  }
+}
+
+async function recognize(base64: string): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await callApi(base64);
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError;
+}
+
+export const vision: OcrVendor = {
+  name: 'vision',
+  timeoutMs,
+  maxRetries,
+  usdPerImage: 0.0015,
+  recognize,
+};
+
+export default vision;
+// END VISION_ADAPTER

--- a/packages/ocr/index.ts
+++ b/packages/ocr/index.ts
@@ -1,0 +1,25 @@
+// BEGIN OCR_PROVIDER_SELECTOR
+import { OcrVendor } from './types';
+import vision from './adapters/vision';
+import ocrspace from './adapters/ocrspace';
+import tesseract from './adapters/tesseract';
+
+const vendors: Record<string, OcrVendor> = {
+  vision,
+  ocrspace,
+  tesseract,
+};
+
+function getEnv(key: string): string | undefined {
+  // Support both Node.js and Deno environments
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const env: any = typeof Deno !== 'undefined' ? Deno.env : process.env;
+  return env?.get ? env.get(key) : env?.[key];
+}
+
+const providerName = getEnv('OCR_PROVIDER')?.toLowerCase();
+export const ocr: OcrVendor =
+  providerName && vendors[providerName] ? vendors[providerName] : tesseract;
+
+export default ocr;
+// END OCR_PROVIDER_SELECTOR

--- a/packages/ocr/types.ts
+++ b/packages/ocr/types.ts
@@ -1,0 +1,17 @@
+// BEGIN OCR_VENDOR_INTERFACE
+export interface OcrVendor {
+  /** Provider identifier */
+  readonly name: string;
+  /** Maximum duration for a single request in milliseconds */
+  readonly timeoutMs: number;
+  /** Number of retry attempts after the initial request */
+  readonly maxRetries: number;
+  /** Approximate USD cost per image processed */
+  readonly usdPerImage: number;
+  /**
+   * Perform OCR on a base64-encoded image and return extracted text.
+   * @param base64Image image encoded as base64 without data URI prefix
+   */
+  recognize(base64Image: string): Promise<string>;
+}
+// END OCR_VENDOR_INTERFACE


### PR DESCRIPTION
## Summary
- add OCR vendor interface and adapters for Google Vision, OCR.space and Tesseract
- select provider via `OCR_PROVIDER` env variable

## Testing
- `npm run verify:functions` (fails: Missing script)

## Checklist
- [x] Files changed
- [ ] Scripts added
- [x] Envs required (GOOGLE_VISION_API_KEY, OCRSPACE_API_KEY, OCR_PROVIDER)
- [ ] Verification results

------
https://chatgpt.com/codex/tasks/task_e_6897044dabc08322a5abad2afea83dfa