### PR TITLE
feat: cache OCR results for receipts

### DIFF
--- a/supabase/functions/ocr-cache/index.ts
+++ b/supabase/functions/ocr-cache/index.ts
@@ -1,0 +1,124 @@
+// BEGIN OCRCACHE
+import { createClient } from "npm:@supabase/supabase-js@2.53.0";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+async function hashFile(file: File): Promise<string> {
+  const arrayBuffer = await file.arrayBuffer();
+  const hashBuffer = await crypto.subtle.digest("SHA-256", arrayBuffer);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+Deno.serve(async (req: Request) => {
+  const url = new URL(req.url);
+  if (url.searchParams.get("health") === "1") {
+    return new Response("ok", { status: 200, headers: corsHeaders });
+  }
+
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 200, headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  const endpoints = Deno.env.get("OCR_ENDPOINTS");
+
+  if (!supabaseUrl || !supabaseKey) {
+    return new Response(JSON.stringify({ error: "Missing Supabase credentials" }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  const formData = await req.formData();
+  const file = formData.get("file");
+
+  if (!(file instanceof File)) {
+    return new Response(JSON.stringify({ error: "Missing file" }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const fileHash = await hashFile(file);
+
+  const { data: existing, error: lookupError } = await supabase
+    .from("ocr_cache")
+    .select("result")
+    .eq("file_hash", fileHash)
+    .maybeSingle();
+
+  if (lookupError) {
+    return new Response(JSON.stringify({ error: "Cache lookup failed" }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  if (existing) {
+    return new Response(
+      JSON.stringify({ cached: true, result: existing.result }),
+      { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+
+  if (url.searchParams.get("dryRun") === "1") {
+    return new Response(JSON.stringify({ file_hash: fileHash, dryRun: true }), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  if (!endpoints) {
+    return new Response(JSON.stringify({ error: "No OCR endpoints configured" }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  let vendor: string;
+  let ocrResult: unknown;
+  try {
+    const list = JSON.parse(endpoints) as string[];
+    vendor = list[0];
+    const resp = await fetch(vendor, { method: "POST", body: file });
+    ocrResult = await resp.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "OCR request failed" }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const { error: insertError } = await supabase.from("ocr_cache").insert({
+    file_hash: fileHash,
+    vendor,
+    result: ocrResult as Record<string, unknown>,
+  });
+
+  if (insertError) {
+    return new Response(JSON.stringify({ error: "Cache insert failed" }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  return new Response(
+    JSON.stringify({ cached: false, result: ocrResult }),
+    { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+  );
+});
+// END OCRCACHE

--- a/supabase/migrations/20250915130000_add_ocr_cache.sql
+++ b/supabase/migrations/20250915130000_add_ocr_cache.sql
@@ -1,0 +1,28 @@
+-- BEGIN OCRCACHE
+/*
+  Create ocr_cache table for storing OCR results
+*/
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE IF NOT EXISTS ocr_cache (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  file_hash text UNIQUE NOT NULL,
+  vendor text NOT NULL,
+  result jsonb NOT NULL,
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE ocr_cache ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access" ON ocr_cache
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "Admin users can read ocr_cache" ON ocr_cache
+  FOR SELECT
+  TO authenticated
+  USING (auth.jwt() ->> 'role' = 'admin');
+-- END OCRCACHE


### PR DESCRIPTION
## Summary
- cache OCR results using file hash
- store OCR results in ocr_cache table with admin-only read

## Testing
- `npm run check:versions` *(fails: Missing script "check:versions")*
- `npm run check:secrets` *(fails: Missing script "check:secrets")*
- `npm run verify:functions` *(fails: Missing script "verify:functions")*


------
https://chatgpt.com/codex/tasks/task_e_68970469a1008322a1980d2c2a3817dc