### PR TITLE
feat: add OCR job queue and worker

### DIFF
--- a/supabase/functions/enqueue/index.ts
+++ b/supabase/functions/enqueue/index.ts
@@ -1,0 +1,93 @@
+// BEGIN ENQUEUE
+import { createClient } from "npm:@supabase/supabase-js@2.53.0";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+Deno.serve(async (req: Request) => {
+  const url = new URL(req.url);
+
+  if (url.searchParams.get("health") === "1") {
+    return new Response(JSON.stringify({ status: "ok" }), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 200, headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !supabaseKey) {
+    return new Response(
+      JSON.stringify({ error: "Missing Supabase credentials" }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  let body: { file_hash?: string; vendor?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON" }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const { file_hash, vendor } = body;
+  if (!file_hash || !vendor) {
+    return new Response(
+      JSON.stringify({ error: "file_hash and vendor required" }),
+      {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  if (url.searchParams.get("dryRun") === "1") {
+    return new Response(JSON.stringify({ status: "dry-run" }), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  const { data, error } = await supabase
+    .from("ocr_jobs")
+    .insert({ file_hash, vendor })
+    .select("id")
+    .single();
+
+  if (error) {
+    return new Response(
+      JSON.stringify({ error: "Database insert failed", details: error.message }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  return new Response(JSON.stringify({ id: data.id }), {
+    status: 200,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+});
+// END ENQUEUE

--- a/supabase/functions/ocr-worker/index.ts
+++ b/supabase/functions/ocr-worker/index.ts
@@ -1,0 +1,115 @@
+// BEGIN OCR_WORKER
+import { createClient } from "npm:@supabase/supabase-js@2.53.0";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+};
+
+async function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+Deno.serve(async (req: Request) => {
+  const url = new URL(req.url);
+
+  if (url.searchParams.get("health") === "1") {
+    return new Response(JSON.stringify({ status: "ok" }), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 200, headers: corsHeaders });
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !supabaseKey) {
+    return new Response(
+      JSON.stringify({ error: "Missing Supabase credentials" }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  const limit = Number(url.searchParams.get("limit") ?? "5");
+  const dryRun = url.searchParams.get("dryRun") === "1";
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  const { data: jobs, error } = await supabase
+    .from("ocr_jobs")
+    .select("id, file_hash, retries, vendor")
+    .eq("status", "queued")
+    .order("id", { ascending: true })
+    .limit(limit);
+
+  if (error) {
+    return new Response(
+      JSON.stringify({ error: "Failed to fetch jobs", details: error.message }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  const endpoints = JSON.parse(Deno.env.get("OCR_ENDPOINTS") || "{}");
+  let processed = 0;
+
+  for (const job of jobs ?? []) {
+    processed += 1;
+    if (!dryRun) {
+      await supabase.from("ocr_jobs").update({ status: "running" }).eq("id", job.id);
+    }
+
+    const endpoint = endpoints[job.vendor];
+    if (!endpoint) {
+      if (!dryRun) {
+        await supabase.from("ocr_jobs").update({ status: "error" }).eq("id", job.id);
+      }
+      continue;
+    }
+
+    try {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ file_hash: job.file_hash }),
+      });
+
+      if (response.status === 429 || response.status >= 500) {
+        const wait = Math.min(1000 * 2 ** job.retries, 30000);
+        await delay(wait);
+        if (!dryRun) {
+          await supabase
+            .from("ocr_jobs")
+            .update({ status: "queued", retries: job.retries + 1 })
+            .eq("id", job.id);
+        }
+      } else if (!response.ok) {
+        if (!dryRun) {
+          await supabase.from("ocr_jobs").update({ status: "error" }).eq("id", job.id);
+        }
+      } else {
+        if (!dryRun) {
+          await supabase.from("ocr_jobs").update({ status: "done" }).eq("id", job.id);
+        }
+      }
+    } catch (_e) {
+      if (!dryRun) {
+        await supabase.from("ocr_jobs").update({ status: "error" }).eq("id", job.id);
+      }
+    }
+  }
+
+  return new Response(JSON.stringify({ processed }), {
+    status: 200,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+});
+// END OCR_WORKER

--- a/supabase/migrations/20250915000000_create_ocr_jobs.sql
+++ b/supabase/migrations/20250915000000_create_ocr_jobs.sql
@@ -1,0 +1,23 @@
+/*
+  Create ocr_jobs table for OCR processing queue
+*/
+
+-- BEGIN OCR_JOBS_TABLE
+CREATE TABLE IF NOT EXISTS ocr_jobs (
+  id serial PRIMARY KEY,
+  file_hash text NOT NULL,
+  status text NOT NULL DEFAULT 'queued' CHECK (status IN ('queued','running','done','error')),
+  retries integer NOT NULL DEFAULT 0,
+  vendor text NOT NULL
+);
+
+ALTER TABLE ocr_jobs ENABLE ROW LEVEL SECURITY;
+
+-- Allow service role full access
+CREATE POLICY "Service role can manage ocr_jobs"
+  ON ocr_jobs
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+-- END OCR_JOBS_TABLE


### PR DESCRIPTION
## Summary
- add ocr_jobs table and service-role policy
- add enqueue edge function for job submissions
- add ocr-worker edge function to process queued jobs

## Testing
- `npm run check:versions` *(fails: Missing script: "check:versions")*
- `npm run check:secrets` *(fails: Missing script: "check:secrets")*
- `npm run verify:functions` *(fails: Missing script: "verify:functions")*


------
https://chatgpt.com/codex/tasks/task_e_68970471cd3483229e33aeffbade11cf