### PR TITLE
feat: add OCRSpace provider configuration

### DIFF
--- a/supabase/functions/_shared/ocr.ts
+++ b/supabase/functions/_shared/ocr.ts
@@ -1,0 +1,19 @@
+// BEGIN OCRSPACE_CONFIG
+export interface OcrProviderConfig {
+  provider: 'ocrspace' | 'vision' | 'tesseract';
+  apiKey?: string;
+  minConfidence: number;
+  allowedMime: string[];
+  maxPages: number;
+}
+
+export const ocrConfig: OcrProviderConfig = {
+  provider: (Deno.env.get('OCR_PROVIDER') as OcrProviderConfig['provider']) ?? 'ocrspace',
+  apiKey: Deno.env.get('OCR_API_KEY'),
+  minConfidence: Number(Deno.env.get('OCR_MIN_CONFIDENCE') ?? '0.8'),
+  allowedMime: JSON.parse(
+    Deno.env.get('OCR_ALLOWED_MIME') ?? '["image/jpeg","image/png","application/pdf"]'
+  ) as string[],
+  maxPages: Number(Deno.env.get('OCR_MAX_PAGES') ?? '3'),
+};
+// END OCRSPACE_CONFIG


### PR DESCRIPTION
## Summary
- add shared OCR configuration for OCRSpace provider driven by env variables

## Testing
- `npm run verify:functions` *(fails: Missing script "verify:functions")*

------
https://chatgpt.com/codex/tasks/task_e_6897048d1b008322aa6f0fa1d30f9d5e